### PR TITLE
Switch to dramatiq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ jobs:
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
-      - image: circleci/rabbitmq:3.7.7
-
+      - image: circleci/redis:latest
       - image: mrnaif/bitcart:latest
         expose: 5000
         command: python3 daemon.py

--- a/gui/models.py
+++ b/gui/models.py
@@ -87,10 +87,10 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
 @receiver(post_save, sender=Wallet)
 def create_wallet(sender, instance=None, created=False, **kwargs):
     if created:
-        tasks.sync_wallet.delay(instance.id, instance.xpub)
+        tasks.sync_wallet.send(instance.id, instance.xpub)
 
 
 @receiver(post_save, sender=Product)
 def create_product(sender, instance=None, created=False, **kwargs):
     if created:
-        tasks.poll_updates.delay(instance.id)
+        tasks.poll_updates.send(instance.id)

--- a/gui/tasks.py
+++ b/gui/tasks.py
@@ -2,7 +2,7 @@
 from django.conf import settings
 from django.utils import timezone
 from asgiref.sync import async_to_sync
-from celery import shared_task
+import dramatiq
 from . import models
 from channels.layers import get_channel_layer
 from bitcart.coins.btc import BTC
@@ -18,7 +18,7 @@ btc = BTC(RPC_URL)
 channel_layer = get_channel_layer()
 
 
-@shared_task
+@dramatiq.actor
 def poll_updates(invoice_id):
     obj = models.Product.objects.get(id=invoice_id)
     address = obj.bitcoin_address
@@ -42,7 +42,7 @@ def poll_updates(invoice_id):
         time.sleep(1)
 
 
-@shared_task
+@dramatiq.actor
 def sync_wallet(wallet_id, xpub):
     model = models.Wallet.objects.get(id=wallet_id)
     try:

--- a/gui/views.py
+++ b/gui/views.py
@@ -370,7 +370,7 @@ def create_product(request):
             form.bitcoin_address = data_got["address"]
             form.bitcoin_url = data_got["URI"]
             form.save()
-            tasks.poll_updates.delay(form.id)
+            tasks.poll_updates.send(form.id)
             return redirect(reverse("products") + "?ok=true")
         else:
             return render(request, "gui/create_product.html", {"form": form})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 django==2.2
-celery==4.3.0
+django_dramatiq==0.7.0
+dramatiq[redis, watch]
 # .env file reading
 python-decouple==3.1
 # drf
 django-rest-framework==0.1.0
-# TODO probably remove this dependency
-channels_rabbitmq==1.0.0
 # websocket
 channels==2.2.0
+channels_redis==2.4.0
 # 2FA
 django-two-factor-auth==1.8.0
 # easy forms


### PR DESCRIPTION
This pull request removes the need of using rabbitmq and uses redis instead. Channels are switched to use it.
Main purpose is to switch to dramatiq instead of celery for tasks processing.